### PR TITLE
Don't load if free (other version) or Pro already loaded

### DIFF
--- a/wp-menu-cart.php
+++ b/wp-menu-cart.php
@@ -16,9 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
 
-if ( class_exists( 'WpMenuCart' ) || class_exists( 'WPO_Menu_Cart_Pro' ) ) {
-	return;
-}
+if ( ! class_exists( 'WpMenuCart' ) && ! class_exists( 'WPO_Menu_Cart_Pro' ) ) :
 
 class WpMenuCart {	 
 
@@ -662,3 +660,5 @@ $wpMenuCart = new WpMenuCart();
 if ( ! empty( $_GET['hide_wpmenucart_shop_check'] ) ) {
 	update_option( 'wpmenucart_shop_check', 'hide' );
 }
+
+endif; // class_exists

--- a/wp-menu-cart.php
+++ b/wp-menu-cart.php
@@ -12,6 +12,14 @@
  * WC tested up to: 5.1.0
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+if ( class_exists( 'WpMenuCart' ) || class_exists( 'WPO_Menu_Cart_Pro' ) ) {
+	return;
+}
+
 class WpMenuCart {	 
 
 	protected $plugin_version = '2.9.7';


### PR DESCRIPTION
prevents fatal crashes and prioritizes Pro over free closes #10 