### PR TITLE
Fix jumping of a menu on the load

### DIFF
--- a/wp-menu-cart.php
+++ b/wp-menu-cart.php
@@ -617,7 +617,11 @@ class WpMenuCart {
 		} elseif ( $context == 'block' ) {
 			$classes .= ' wp-block-navigation-item wp-block-navigation-link';
 		}
-
+		// Fix jumping of a menu on the load 
+		$item_data = $this->shop->menu_item();
+		if ( $item_data['cart_contents_count'] == 0 && ! isset( $this->options['always_display'] ) && ! $this->is_block_editor() ) {
+			$classes .= ' empty-wpmenucart';
+		}
 		// Filter for <li> item classes
 		/* Usage (in the themes functions.php):
 		add_filter('wpmenucart_menu_item_classes', 'add_wpmenucart_item_class', 1, 1);


### PR DESCRIPTION
When cart is hidden when empty - menu jumping a bit to the left on the page load because it loads from PHP without empty-wpmenucart class attached.
Fix checks if there are any items in the cart on server side and assigns proper class.