### PR TITLE
Bug fixes. Prevents "Undefined array key" errors 

### DIFF
--- a/wp-menu-cart.php
+++ b/wp-menu-cart.php
@@ -638,7 +638,9 @@ class WpMenuCart {
 	 * @return string
 	 */
 	public function generate_menu_item_li( $classes, $context = 'classic' ) {
-		$classes .= ' wpmenucartli wpmenucart-display-' . $this->options['items_alignment'];
+		if ( ! empty( $this->options['items_alignment'] ) ) {
+			$classes .= ' wpmenucartli wpmenucart-display-' . $this->options['items_alignment'];
+		}
 		if ( function_exists( 'is_checkout' ) && function_exists( 'is_cart' ) && ( is_checkout() || is_cart() ) && empty( $this->options['show_on_cart_checkout_page'] ) ) {
 			$classes .= ' hidden-wpmenucart';
 		}
@@ -795,16 +797,18 @@ class WpMenuCart {
 			$menu_item_icon = '';
 		}
 		
-		switch ( $this->options['items_display'] ) {
-			case 1: //items only
-				$menu_item_a_content .= '<span class="cartcontents">'.$cart_contents.'</span>';
-				break;
-			case 2: //price only
-				$menu_item_a_content .= '<span class="amount">'.$item_data['cart_total'].'</span>';
-				break;
-			case 3: //items & price
-				$menu_item_a_content .= '<span class="cartcontents">'.$cart_contents.'</span><span class="amount">'.$item_data['cart_total'].'</span>';
-				break;
+		if ( ! empty( $this->options['items_display'] ) ) {
+			switch ( $this->options['items_display'] ) {
+				case 1: //items only
+					$menu_item_a_content .= '<span class="cartcontents">'.$cart_contents.'</span>';
+					break;
+				case 2: //price only
+					$menu_item_a_content .= '<span class="amount">'.$item_data['cart_total'].'</span>';
+					break;
+				case 3: //items & price
+					$menu_item_a_content .= '<span class="cartcontents">'.$cart_contents.'</span><span class="amount">'.$item_data['cart_total'].'</span>';
+					break;
+			}
 		}
 		$menu_item_a_content = apply_filters( 'wpmenucart_menu_item_a_content', $menu_item_a_content, $menu_item_icon, $cart_contents, $item_data );
 


### PR DESCRIPTION
Bug fixes. Prevents "Undefined array key" errors when plugin is active and no radio button choices are chosen on settings page.

```
[19-Mar-2024 22:30:28 UTC] PHP Warning:  Undefined array key "items_alignment" in /home/rzj/public_html/wp-content/plugins/wp-menu-cart/wp-menu-cart.php on line 641
[19-Mar-2024 22:30:28 UTC] PHP Warning:  Undefined array key "items_display" in /home/rzj/public_html/wp-content/plugins/wp-menu-cart/wp-menu-cart.php on line 798
```