### PR TITLE
Fix issue with using `wc_get_cart_url()` in the latest version of Woo

### DIFF
--- a/includes/wpmenucart-edd.php
+++ b/includes/wpmenucart-edd.php
@@ -2,10 +2,8 @@
 if ( ! class_exists( 'WPMenuCart_EDD' ) ) {
 	class WPMenuCart_EDD {	
 		public function menu_item() {
-			global $post;
-	
 			$menu_item = array(
-				'cart_url'            => edd_get_checkout_uri(),
+				'cart_url'            => apply_filters( 'wpmenucart_cart_url', edd_get_checkout_uri(), $this ),
 				'shop_page_url'       => get_home_url(),
 				'cart_contents_count' => edd_get_cart_quantity(),
 				'cart_total'          => edd_currency_filter( edd_format_amount( edd_get_cart_total() ) ),

--- a/includes/wpmenucart-woocommerce.php
+++ b/includes/wpmenucart-woocommerce.php
@@ -11,7 +11,7 @@ if ( ! class_exists( 'WPMenuCart_WooCommerce' ) ) {
 			$this->maybe_load_cart(); // make sure cart is loaded! https://wordpress.org/support/topic/activation-breaks-customise?replies=10#post-7908988
 
 			$menu_item = array(
-				'cart_url'            => wc_get_page_permalink( 'cart' ),
+				'cart_url'            => apply_filters( 'woocommerce_get_cart_url', wc_get_page_permalink( 'cart' ) ),
 				'shop_page_url'       => wc_get_page_permalink( 'shop' ),
 				'cart_total'          => strip_tags( $this->get_cart_total() ),
 				'cart_contents_count' => $this->get_cart_contents_count(),

--- a/includes/wpmenucart-woocommerce.php
+++ b/includes/wpmenucart-woocommerce.php
@@ -92,7 +92,19 @@ if ( ! class_exists( 'WPMenuCart_WooCommerce' ) ) {
 			return $cart_contents_total;
 		}
 
-		public function get_cart_url() {
+		/**
+		 * Get the cart URL.
+		 *
+		 * Taking into account the changes made to `wc_get_cart_url()` in WooCommerce version 9.3.0,
+		 * the `wc_get_cart_url()` may return the current URL during AJAX requests,
+		 * which could result in incorrect URLs like `/?wc-ajax=add_to_cart`.
+		 *
+		 * To ensure the correct cart page URL is returned, the `wc_get_page_permalink( 'cart' )`
+		 * has been used instead, with a filter to allow further customizations.
+		 *
+		 * @return string The filtered cart URL.
+		 */
+		public function get_cart_url(): string {
 			$wc_cart_url = apply_filters( 'woocommerce_get_cart_url', wc_get_page_permalink( 'cart' ) );
 			return apply_filters( 'wpmenucart_cart_url', $wc_cart_url, $this );
 		}

--- a/includes/wpmenucart-woocommerce.php
+++ b/includes/wpmenucart-woocommerce.php
@@ -94,7 +94,7 @@ if ( ! class_exists( 'WPMenuCart_WooCommerce' ) ) {
 
 		public function get_cart_url() {
 			$wc_cart_url = apply_filters( 'woocommerce_get_cart_url', wc_get_page_permalink( 'cart' ) );
-			return apply_filters( 'wpmenucart_cart_url', $wc_cart_url );
+			return apply_filters( 'wpmenucart_cart_url', $wc_cart_url, $this );
 		}
 	}
 }

--- a/includes/wpmenucart-woocommerce.php
+++ b/includes/wpmenucart-woocommerce.php
@@ -11,7 +11,7 @@ if ( ! class_exists( 'WPMenuCart_WooCommerce' ) ) {
 			$this->maybe_load_cart(); // make sure cart is loaded! https://wordpress.org/support/topic/activation-breaks-customise?replies=10#post-7908988
 
 			$menu_item = array(
-				'cart_url'            => wc_get_cart_url(),
+				'cart_url'            => wc_get_page_permalink( 'cart' ),
 				'shop_page_url'       => wc_get_page_permalink( 'shop' ),
 				'cart_total'          => strip_tags( $this->get_cart_total() ),
 				'cart_contents_count' => $this->get_cart_contents_count(),

--- a/includes/wpmenucart-woocommerce.php
+++ b/includes/wpmenucart-woocommerce.php
@@ -11,7 +11,7 @@ if ( ! class_exists( 'WPMenuCart_WooCommerce' ) ) {
 			$this->maybe_load_cart(); // make sure cart is loaded! https://wordpress.org/support/topic/activation-breaks-customise?replies=10#post-7908988
 
 			$menu_item = array(
-				'cart_url'            => apply_filters( 'woocommerce_get_cart_url', wc_get_page_permalink( 'cart' ) ),
+				'cart_url'            => $this->get_cart_url(),
 				'shop_page_url'       => wc_get_page_permalink( 'shop' ),
 				'cart_total'          => strip_tags( $this->get_cart_total() ),
 				'cart_contents_count' => $this->get_cart_contents_count(),
@@ -90,6 +90,11 @@ if ( ! class_exists( 'WPMenuCart_WooCommerce' ) ) {
 			}
 
 			return $cart_contents_total;
+		}
+
+		public function get_cart_url() {
+			$wc_cart_url = apply_filters( 'woocommerce_get_cart_url', wc_get_page_permalink( 'cart' ) );
+			return apply_filters( 'wpmenucart_cart_url', $wc_cart_url );
 		}
 	}
 }


### PR DESCRIPTION
It looks like they changed the wc_get_cart_url() function in version `9.3.0` of WooCommerce [here](https://github.com/woocommerce/woocommerce/blob/1b28b0f1ca2cdfa3bab7a4d13a299a5067f3af31/plugins/woocommerce/includes/wc-core-functions.php#L1478-L1493), to also support shortcodes on other pages besides the main cart page.
This returns the current URL when we call `wc_get_cart_url()`  during the AJAX add to cart call. Which is `/?wc-ajax=add_to_cart`. So the cart link changes from the correct cart page to this AJAX url when adding an item to the cart. Leading users to a blank page when they click it.