### PR TITLE
Fix deploy.sh

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -21,6 +21,9 @@ svn update --set-depth infinity tags/$VERSION
 # Copy files from release to `svn/trunk`
 rsync -rcm --exclude-from="$GITHUB_WORKSPACE/.distignore" "$GITHUB_WORKSPACE/" trunk/ --delete --delete-excluded 
 
+# Detect and schedule deletions in SVN
+svn status | grep '^!' | awk '{print $2}' | xargs -r svn delete
+
 # Prepare the files for commit in SVN
 svn add --force trunk
 


### PR DESCRIPTION
After looking at the script, it seems the issue is as described below:
The `rsync` command uses the `--delete` and `--delete-excluded` options. These options remove files from the destination (`trunk/`) that are not present in the source (`$GITHUB_WORKSPACE/`).
However, while `rsync` deletes these files from the working directory, SVN is not automatically aware of these deletions. SVN tracks files at the repository level, and merely deleting them from the working directory doesn't inform SVN to remove them from version control.
So, since SVN isn't informed about the deletions, the old files remain in the repository.

To solve it, I added a line to explicitly tell SVN to remove the files that have been deleted by rsync.